### PR TITLE
Changed some HTTP status codes & moved when email is sent

### DIFF
--- a/server/routes/register.js
+++ b/server/routes/register.js
@@ -16,7 +16,7 @@ router.post("/", async (req, res) => {
 
     if (takenUsername || takenEmail) {
       return res
-        .status(403)
+        .status(400)
         .json({ msg: "Username or email has already been taken." });
     } else {
       user.password = await bcrypt.hash(req.body.password, 10);
@@ -29,15 +29,15 @@ router.post("/", async (req, res) => {
         password: user.password,
       });
 
-      sendEmail.sendEmailRegister(user.email, user.firstName);
       await dbUser.save();
+      sendEmail.sendEmailRegister(user.email, user.firstName);
 
       // sendEmail.sendEmailRegister(takenEmail, user.firstName);
 
-      return res.status(200).json({ msg: "Your account has been created." });
+      return res.status(201).json({ msg: "Your account has been created successfully." });
     }
   } catch (error) {
-    return res.status(403).json({ msg: "Registration Failed" });
+    return res.status(500).json({ msg: "Registration Failed." });
   }
 });
 


### PR DESCRIPTION
Account creation email was getting sent before the User was stored in the database, so it was possible to have registration fail due to a bad request & the user still be emailed that their account was created.